### PR TITLE
attack-on-voxelburg: improve metadata

### DIFF
--- a/entries/attack-on-voxelburg/game.json
+++ b/entries/attack-on-voxelburg/game.json
@@ -24,5 +24,8 @@
     "slug": "attack-on-voxelburg",
     "title": "Attack on Voxelburg",
     "platform": "GBA",
+    "repository": "https://github.com/MutantStargoat/voxelburg",
+    "video": "https://www.youtube.com/watch?v=zla7kgzgr2w",
+    "license": "GPL-3.0-or-later",
     "description": "GameBoy Advance terrain shooter game for the gbajam22"
 }


### PR DESCRIPTION
Adding info to the voxelburg metadata:
  - source code repository on github
  - video on youtube
  - license